### PR TITLE
Structured activities + different conversion algorithm

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -22,7 +22,7 @@ Here is a list of BPEL elements and whether they are implemented or not.
 - [x] RepeatUntil (this needs a mapping for expression languages)
 - [x] Reply (implemented without operation reference)
 - [x] Rethrow
-- [ ] Scope (only simple encapsulation of child proccesses are mapped)
+- [ ] Scope (only simple encapsulation of child proccesses are mapped, no sub process logic)
 - [x] Sequence
 - [x] Throw
 - [ ] Variables (this isn't fully mappable)

--- a/README.MD
+++ b/README.MD
@@ -17,12 +17,12 @@ Here is a list of BPEL elements and whether they are implemented or not.
 - [x] Import
 - [x] Invoke (implemented without operation reference and fault handlers)
 - [x] PartnerLink (implemented without WSDL interfaces + messages)
-- [ ] Pick
+- [x] Pick (added intermediate catch event at the end to connect the next activity)
 - [x] Receive
 - [x] RepeatUntil (this needs a mapping for expression languages)
 - [x] Reply (implemented without operation reference)
 - [x] Rethrow
-- [ ] Scope (only simple encapsulation of child proccesses are mapped, no sub process logic)
+- [ ] Scope (only implemented simple encapsulation of child proccesses are mapped, no sub process logic)
 - [x] Sequence
 - [x] Throw
 - [ ] Variables (this isn't fully mappable)

--- a/README.MD
+++ b/README.MD
@@ -22,7 +22,7 @@ Here is a list of BPEL elements and whether they are implemented or not.
 - [x] RepeatUntil (this needs a mapping for expression languages)
 - [x] Reply (implemented without operation reference)
 - [x] Rethrow
-- [ ] Scope
+- [ ] Scope (only simple encapsulation of child proccesses are mapped)
 - [x] Sequence
 - [x] Throw
 - [ ] Variables (this isn't fully mappable)

--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ Here is a list of BPEL elements and whether they are implemented or not.
 - [x] Documentation
 - [ ] FaultHandlers
 - [ ] Flow
-- [ ] ForEach
+- [ ] ForEach (not mapped due to lack of mapping for expression languages)
 - [x] If
 - [x] Import
 - [x] Invoke (implemented without operation reference and fault handlers)

--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ Here is a list of BPEL elements and whether they are implemented or not.
 - [x] Exit
 - [x] Documentation
 - [ ] FaultHandlers
-- [ ] Flow
+- [x] Flow (implemented without failures and suppressJoinFailure since this needs some expression language)
 - [ ] ForEach (not mapped due to lack of mapping for expression languages)
 - [x] If
 - [x] Import

--- a/src/main/java/org/bpel2bpmn/controllers/BPELController.java
+++ b/src/main/java/org/bpel2bpmn/controllers/BPELController.java
@@ -62,6 +62,11 @@ public class BPELController {
 
             return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
                     .body(buildErrorXML("This BPEL file cannot be converted; " + e.getMessage()));
+        } catch (Exception e) {
+            LOG.error("Unexpected exception; " + e.getMessage());
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(buildErrorXML("Something went wrong server side."));
         }
     }
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/BPELObject.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/BPELObject.java
@@ -3,6 +3,7 @@ package org.bpel2bpmn.models.bpel;
 import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.activities.structured.Scope;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.jdom.Document;
 import org.slf4j.Logger;
@@ -70,7 +71,7 @@ public abstract class BPELObject {
      * @param from the BPMN element to which the newly mapped element should be connected
      * @return a BPMN element
      */
-    public abstract FlowNode toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException;
+    public abstract MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException;
 
     /*
      * Getters & Setters

--- a/src/main/java/org/bpel2bpmn/models/bpel/Process.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/Process.java
@@ -86,7 +86,10 @@ public class Process extends BPELObject {
         FlowNode lastElement = start;
         for (BPELObject child : children) {
             MappedPair mapping = child.toBPMN(builder, lastElement);
-            lastElement = mapping.getEndNode();
+            if (!mapping.isEmpty()) {
+                builder.createSequenceFlow(lastElement, mapping.getStartNode());
+                lastElement = mapping.getEndNode();
+            }
         }
 
         if (lastElement.getClass() != EndEventImpl.class) {

--- a/src/main/java/org/bpel2bpmn/models/bpel/Process.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/Process.java
@@ -3,6 +3,7 @@ package org.bpel2bpmn.models.bpel;
 import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.generic.PartnerLink;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
@@ -53,8 +54,8 @@ public class Process extends BPELObject {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
-        return from;
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
+        return new MappedPair();
     }
 
     public ValidationResult validate() {
@@ -84,7 +85,8 @@ public class Process extends BPELObject {
         // Map and connect children.
         FlowNode lastElement = start;
         for (BPELObject child : children) {
-            lastElement = child.toBPMN(builder, start);
+            MappedPair mapping = child.toBPMN(builder, lastElement);
+            lastElement = mapping.getEndNode();
         }
 
         if (lastElement.getClass() != EndEventImpl.class) {

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/Activity.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/Activity.java
@@ -36,9 +36,6 @@ public abstract class Activity extends BPELObject {
             "suppressJoinFailure"
     };
 
-    /* The standard elements for an activity */
-    // TODO: Implement standard elements.
-
     public Activity() {
         addAttribute("suppressJoinFailure", "no");
     }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Assign.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Assign.java
@@ -3,12 +3,13 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 public class Assign extends Activity {
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
         throw new BPELConversionException("There is no mapping defined from the 'assign' activity to a BPMN construct.", "assign");
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Empty.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Empty.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 public class Empty extends Activity {
@@ -15,7 +16,7 @@ public class Empty extends Activity {
      * @return previous activity (such that it can be mapped to the next activity).
      */
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
-        return from;
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
+        return new MappedPair();
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Exit.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Exit.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.EndEvent;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.TerminateEventDefinition;
@@ -13,11 +14,11 @@ public class Exit extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         EndEvent endEvent = builder.createElement(EndEvent.class);
         builder.createElement(endEvent, TerminateEventDefinition.class);
 
-        return endEvent;
+        return new MappedPair(endEvent);
     }
 
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Exit.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Exit.java
@@ -20,5 +20,4 @@ public class Exit extends Activity {
 
         return new MappedPair(endEvent);
     }
-
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Invoke.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Invoke.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
 import org.camunda.bpm.model.bpmn.impl.instance.SourceRef;
 import org.camunda.bpm.model.bpmn.impl.instance.TargetRef;
@@ -22,17 +23,19 @@ public class Invoke extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
-        FlowNode lastNode = createSendTask(builder);
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
+        SendTask sendTask = createSendTask(builder);
+        MappedPair result = new MappedPair(sendTask);
 
         // Map for synchronous invoke
         if (isSynchronous()) {
-            lastNode = createReceiveTask(builder, (SendTask) lastNode);
+             ReceiveTask receiveTask = createReceiveTask(builder, sendTask);
+             result.setEndNode(receiveTask);
         }
 
         // Note: Fault handlers are not implemented. Implementation should be placed around here.
 
-        return lastNode;
+        return result;
     }
 
     private SendTask createSendTask(BPMNBuilder builder) {

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Invoke.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Invoke.java
@@ -41,7 +41,7 @@ public class Invoke extends Activity {
     private SendTask createSendTask(BPMNBuilder builder) {
         // Create send task
         SendTask sendTask = builder.createElement(SendTask.class);
-            // Note: operation should be added to the send task, but this would invalidate the BPMN model
+            // Note: operation should be added to the send task, but this will invalidate the BPMN model
 
         Property property = builder.createElement(sendTask, Property.class);
 
@@ -66,7 +66,7 @@ public class Invoke extends Activity {
 
     private ReceiveTask createReceiveTask(BPMNBuilder builder, SendTask sendTask) {
         ReceiveTask receiveTask = builder.createElement(ReceiveTask.class);
-            // Note: operation should be added to the receive task, but this would invalidate the BPMN model
+            // Note: operation should be added to the receive task, but this will invalidate the BPMN model
 
         Property property = builder.createElement(receiveTask, Property.class);
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Receive.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Receive.java
@@ -1,5 +1,6 @@
 package org.bpel2bpmn.models.bpel.activities.basic;
 
+import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
@@ -24,13 +25,19 @@ public class Receive extends Activity {
     }
 
     @Override
-    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+        IntermediateCatchEvent event = createMessageEvent(builder);
+
+        return new MappedPair(event);
+    }
+
+    protected IntermediateCatchEvent createMessageEvent(BPMNBuilder builder) {
         IntermediateCatchEvent event = builder.createElement(IntermediateCatchEvent.class);
         builder.createElement(event, MessageEventDefinition.class);
 
         builder.createMessageFlow(event, attributes.get("partnerLink"), true);
 
-        return new MappedPair(event);
+        return event;
     }
 
     public ValidationResult validate() {

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Receive.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Receive.java
@@ -2,8 +2,8 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
-import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.IntermediateCatchEvent;
 import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition;
@@ -24,16 +24,14 @@ public class Receive extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
-        BpmnModelInstance modelInstance = builder.getModelInstance();
-
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         IntermediateCatchEvent event = builder.createElement(IntermediateCatchEvent.class);
-        MessageEventDefinition message = modelInstance.newInstance(MessageEventDefinition.class);
+        MessageEventDefinition message = builder.createElement(event, MessageEventDefinition.class);
         event.addChildElement(message);
 
         builder.createMessageFlow(event, attributes.get("partnerLink"), true);
 
-        return event;
+        return new MappedPair(event);
     }
 
     public ValidationResult validate() {

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Receive.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Receive.java
@@ -26,8 +26,7 @@ public class Receive extends Activity {
     @Override
     public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         IntermediateCatchEvent event = builder.createElement(IntermediateCatchEvent.class);
-        MessageEventDefinition message = builder.createElement(event, MessageEventDefinition.class);
-        event.addChildElement(message);
+        builder.createElement(event, MessageEventDefinition.class);
 
         builder.createMessageFlow(event, attributes.get("partnerLink"), true);
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Reply.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Reply.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.IntermediateThrowEvent;
@@ -23,13 +24,13 @@ public class Reply extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         IntermediateThrowEvent messageEvent = builder.createElement(IntermediateThrowEvent.class);
         builder.createElement(messageEvent, MessageEventDefinition.class);
         builder.createMessageFlow(messageEvent, attributes.get("partnerLink"), false);
             // Note: operation should be added to the message event, but this would invalidate the BPMN model
 
-        return messageEvent;
+        return new MappedPair(messageEvent);
     }
 
     public ValidationResult validate() {

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Reply.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Reply.java
@@ -28,7 +28,7 @@ public class Reply extends Activity {
         IntermediateThrowEvent messageEvent = builder.createElement(IntermediateThrowEvent.class);
         builder.createElement(messageEvent, MessageEventDefinition.class);
         builder.createMessageFlow(messageEvent, attributes.get("partnerLink"), false);
-            // Note: operation should be added to the message event, but this would invalidate the BPMN model
+            // Note: operation should be added to the message event, but this will invalidate the BPMN model
 
         return new MappedPair(messageEvent);
     }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Rethrow.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Rethrow.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.EndEvent;
 import org.camunda.bpm.model.bpmn.instance.ErrorEventDefinition;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
@@ -13,11 +14,10 @@ public class Rethrow extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         EndEvent event = builder.createElement(EndEvent.class);
-        ErrorEventDefinition error = builder.getModelInstance().newInstance(ErrorEventDefinition.class);
-        event.addChildElement(error);
+        builder.createElement(event, ErrorEventDefinition.class);
 
-        return event;
+        return new MappedPair(event);
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Throw.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Throw.java
@@ -5,10 +5,8 @@ import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.camunda.bpm.model.bpmn.instance.EndEvent;
+import org.camunda.bpm.model.bpmn.instance.*;
 import org.camunda.bpm.model.bpmn.instance.Error;
-import org.camunda.bpm.model.bpmn.instance.ErrorEventDefinition;
-import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 public class Throw extends Activity {
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Throw.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Throw.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.EndEvent;
@@ -23,18 +24,17 @@ public class Throw extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         BpmnModelInstance modelInstance = builder.getModelInstance();
 
         Error error = builder.createElement(modelInstance.getDefinitions(), Error.class);
         error.setName(getFaultName());
 
         FlowNode endEvent = builder.createElement(EndEvent.class);
-        ErrorEventDefinition errorEventDef = modelInstance.newInstance(ErrorEventDefinition.class);
+        ErrorEventDefinition errorEventDef = builder.createElement(endEvent, ErrorEventDefinition.class);
         errorEventDef.setError(error);
-        endEvent.addChildElement(errorEventDef);
 
-        return endEvent;
+        return new MappedPair(endEvent);
     }
 
     public ValidationResult validate() {

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Wait.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Wait.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.*;
 
 public class Wait extends Activity {
@@ -16,7 +17,7 @@ public class Wait extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         IntermediateCatchEvent intermediateEvent = builder.createElement(IntermediateCatchEvent.class);
         TimerEventDefinition timer = builder.createElement(intermediateEvent, TimerEventDefinition.class);
 
@@ -28,7 +29,7 @@ public class Wait extends Activity {
             timeDate.setTextContent(timeExpression);
         }
 
-        return intermediateEvent;
+        return new MappedPair(intermediateEvent);
     }
 
     /*

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Wait.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/basic/Wait.java
@@ -1,5 +1,6 @@
 package org.bpel2bpmn.models.bpel.activities.basic;
 
+import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
@@ -7,8 +8,8 @@ import org.camunda.bpm.model.bpmn.instance.*;
 
 public class Wait extends Activity {
 
-    private boolean isTimer; /* true in case of a <for> construct, false in case of a <until> construct. */
-    private String timeExpression; /* Represents either the duration or deadline expression */
+    protected boolean isTimer; /* true in case of a <for> construct, false in case of a <until> construct. */
+    protected String timeExpression; /* Represents either the duration or deadline expression */
 
     public Wait() {
         super();
@@ -17,7 +18,13 @@ public class Wait extends Activity {
     }
 
     @Override
-    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+        IntermediateCatchEvent intermediateEvent = createTimerEvent(builder);
+
+        return new MappedPair(intermediateEvent);
+    }
+
+    protected IntermediateCatchEvent createTimerEvent(BPMNBuilder builder) {
         IntermediateCatchEvent intermediateEvent = builder.createElement(IntermediateCatchEvent.class);
         TimerEventDefinition timer = builder.createElement(intermediateEvent, TimerEventDefinition.class);
 
@@ -29,7 +36,7 @@ public class Wait extends Activity {
             timeDate.setTextContent(timeExpression);
         }
 
-        return new MappedPair(intermediateEvent);
+        return intermediateEvent;
     }
 
     /*

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Branch.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Branch.java
@@ -25,18 +25,20 @@ public class Branch extends Activity {
 
     @Override
     public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
-        FlowNode lastElement = from;
         MappedPair result = new MappedPair();
+        FlowNode lastElement = null;
 
         boolean isFirstChild = true;
         for (BPELObject child : children) {
             builder.prepareConditionalSequenceFlow(condition);
 
             MappedPair mapping = child.toBPMN(builder, lastElement);
-            builder.createSequenceFlow(lastElement, mapping.getStartNode());
-            lastElement = mapping.getEndNode();
+            if (!mapping.isEmpty()) {
+                builder.createSequenceFlow(lastElement, mapping.getStartNode());
+                lastElement = mapping.getEndNode();
+            }
 
-            if (isFirstChild) {
+            if (isFirstChild && !mapping.isEmpty()) {
                 result.setStartNode(mapping.getStartNode());
                 isFirstChild = false;
             }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Flow.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Flow.java
@@ -5,10 +5,7 @@ import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
-import org.camunda.bpm.model.bpmn.instance.ComplexGateway;
-import org.camunda.bpm.model.bpmn.instance.FlowNode;
-import org.camunda.bpm.model.bpmn.instance.ParallelGateway;
-import org.camunda.bpm.model.bpmn.instance.SequenceFlow;
+import org.camunda.bpm.model.bpmn.instance.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,10 +22,8 @@ public class Flow extends Activity {
 
     @Override
     public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
-        ComplexGateway afterGateway = builder.createElement(ComplexGateway.class);
         ParallelGateway beforeGateway = builder.createElement(ParallelGateway.class);
-
-        builder.createSequenceFlow(from, beforeGateway);
+        ComplexGateway afterGateway = builder.createElement(ComplexGateway.class);
 
         // No links
         if (links.size() < 1) {
@@ -80,8 +75,7 @@ public class Flow extends Activity {
             }
         }
 
-
-        // TODO: Take into account JoinSupressionFail
+        // Note: failures and therefore suppressJoinFailure are not implemented
 
         return new MappedPair(beforeGateway, afterGateway);
     }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/ForEach.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/ForEach.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.structured;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 public class ForEach extends Activity {
@@ -20,7 +21,7 @@ public class ForEach extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         return null;
     }
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/ForEach.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/ForEach.java
@@ -1,5 +1,6 @@
 package org.bpel2bpmn.models.bpel.activities.structured;
 
+import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
@@ -12,17 +13,16 @@ public class ForEach extends Activity {
     private boolean parallel;
 
     /* ForEach specific elements */
-    private String startCounterValue;
-    private String finalCounterValue;
-    // TODO: Implement scope element
+    private int startCounterValue;
+    private int finalCounterValue;
 
     public ForEach() {
         super();
     }
 
     @Override
-    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
-        return null;
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+        throw new BPELConversionException("There is no mapping defined from the 'forEach' activity to a BPMN construct.", "forEach");
     }
 
     /*
@@ -43,5 +43,21 @@ public class ForEach extends Activity {
 
     public void setParallel(boolean parallel) {
         this.parallel = parallel;
+    }
+
+    public int getStartCounterValue() {
+        return startCounterValue;
+    }
+
+    public void setStartCounterValue(int startCounterValue) {
+        this.startCounterValue = startCounterValue;
+    }
+
+    public int getFinalCounterValue() {
+        return finalCounterValue;
+    }
+
+    public void setFinalCounterValue(int finalCounterValue) {
+        this.finalCounterValue = finalCounterValue;
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/If.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/If.java
@@ -26,23 +26,22 @@ public class If extends Activity {
     public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
         // Gateway to diverge incoming branch
         ExclusiveGateway divergeGateway = builder.createElement(ExclusiveGateway.class);
-        builder.createSequenceFlow(from, divergeGateway);
 
         // Gateway to join branches
         ExclusiveGateway joinGateway = builder.createElement(ExclusiveGateway.class);
 
         // Map branches
         FlowNode node = ifBranch.toBPMN(builder, divergeGateway).getEndNode();
-        mapSequenceFlow(builder, node, joinGateway);
+        if (node != null) mapSequenceFlow(builder, node, joinGateway);
 
         for (Branch elseIfBranch : elseIfBranches) {
             node = elseIfBranch.toBPMN(builder, divergeGateway).getEndNode();
-            mapSequenceFlow(builder, node, joinGateway);
+            if (node != null) mapSequenceFlow(builder, node, joinGateway);
         }
 
         if (elseBranch != null) {
             node = elseBranch.toBPMN(builder, divergeGateway).getEndNode();
-            mapSequenceFlow(builder, node, joinGateway);
+            if (node != null) mapSequenceFlow(builder, node, joinGateway);
             // The mapping describes a 'default' sequence flow. This is purely for notation purposes and will be ignored.
         }
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/If.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/If.java
@@ -3,6 +3,7 @@ package org.bpel2bpmn.models.bpel.activities.structured;
 import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.impl.instance.EndEventImpl;
 import org.camunda.bpm.model.bpmn.instance.ExclusiveGateway;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
@@ -22,7 +23,7 @@ public class If extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
         // Gateway to diverge incoming branch
         ExclusiveGateway divergeGateway = builder.createElement(ExclusiveGateway.class);
         builder.createSequenceFlow(from, divergeGateway);
@@ -31,21 +32,21 @@ public class If extends Activity {
         ExclusiveGateway joinGateway = builder.createElement(ExclusiveGateway.class);
 
         // Map branches
-        FlowNode node = ifBranch.toBPMN(builder, divergeGateway);
+        FlowNode node = ifBranch.toBPMN(builder, divergeGateway).getEndNode();
         mapSequenceFlow(builder, node, joinGateway);
 
         for (Branch elseIfBranch : elseIfBranches) {
-            node = elseIfBranch.toBPMN(builder, divergeGateway);
+            node = elseIfBranch.toBPMN(builder, divergeGateway).getEndNode();
             mapSequenceFlow(builder, node, joinGateway);
         }
 
         if (elseBranch != null) {
-            node = elseBranch.toBPMN(builder, divergeGateway);
+            node = elseBranch.toBPMN(builder, divergeGateway).getEndNode();
             mapSequenceFlow(builder, node, joinGateway);
             // The mapping describes a 'default' sequence flow. This is purely for notation purposes and will be ignored.
         }
 
-        return joinGateway;
+        return new MappedPair(divergeGateway, joinGateway);
     }
 
     private void mapSequenceFlow(BPMNBuilder builder, FlowNode from, FlowNode to) {

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnAlarm.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnAlarm.java
@@ -1,10 +1,11 @@
 package org.bpel2bpmn.models.bpel.activities.structured;
 
+import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.basic.Wait;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
-import org.camunda.bpm.model.bpmn.instance.FlowNode;
+import org.camunda.bpm.model.bpmn.instance.*;
 
 import java.util.ArrayList;
 
@@ -18,8 +19,19 @@ public class OnAlarm extends Wait {
     }
 
     @Override
-    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
-        return null;
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+        IntermediateCatchEvent timerEvent = createTimerEvent(builder);
+
+        FlowNode lastNode = timerEvent;
+        for (BPELObject child : children) {
+            MappedPair mapping = child.toBPMN(builder, lastNode);
+            if (!mapping.isEmpty()) {
+                builder.createSequenceFlow(lastNode, mapping.getStartNode());
+                lastNode = mapping.getEndNode();
+            }
+        }
+
+        return new MappedPair(timerEvent, lastNode);
     }
 
     /*

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnAlarm.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnAlarm.java
@@ -3,6 +3,7 @@ package org.bpel2bpmn.models.bpel.activities.structured;
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.basic.Wait;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 import java.util.ArrayList;
@@ -17,7 +18,7 @@ public class OnAlarm extends Wait {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         return null;
     }
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnMessage.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnMessage.java
@@ -1,10 +1,12 @@
 package org.bpel2bpmn.models.bpel.activities.structured;
 
+import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.basic.Receive;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
+import org.camunda.bpm.model.bpmn.instance.IntermediateCatchEvent;
 
 import java.util.ArrayList;
 
@@ -18,8 +20,19 @@ public class OnMessage extends Receive {
     }
 
     @Override
-    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
-        return null;
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+        IntermediateCatchEvent messageEvent = createMessageEvent(builder);
+
+        FlowNode lastNode = messageEvent;
+        for (BPELObject child : children) {
+            MappedPair mapping = child.toBPMN(builder, lastNode);
+            if (!mapping.isEmpty()) {
+                builder.createSequenceFlow(lastNode, mapping.getStartNode());
+                lastNode = mapping.getEndNode();
+            }
+        }
+
+        return new MappedPair(messageEvent, lastNode);
     }
 
     /*

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnMessage.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/OnMessage.java
@@ -3,6 +3,7 @@ package org.bpel2bpmn.models.bpel.activities.structured;
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.basic.Receive;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 import java.util.ArrayList;
@@ -17,7 +18,7 @@ public class OnMessage extends Receive {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         return null;
     }
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Pick.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Pick.java
@@ -1,9 +1,12 @@
 package org.bpel2bpmn.models.bpel.activities.structured;
 
+import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
+import org.camunda.bpm.model.bpmn.instance.EventBasedGateway;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
+import org.camunda.bpm.model.bpmn.instance.IntermediateCatchEvent;
 
 import java.util.ArrayList;
 
@@ -18,16 +21,32 @@ public class Pick extends Activity {
         alarmEvents = new ArrayList<>();
     }
 
+    @Override
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+        EventBasedGateway startGateway = builder.createElement(EventBasedGateway.class);
+        IntermediateCatchEvent catchEvent = builder.createElement(IntermediateCatchEvent.class);
+
+        MappedPair mapping;
+        for (OnMessage messageEvent : messageEvents) {
+            mapping = messageEvent.toBPMN(builder, startGateway);
+            builder.createSequenceFlow(startGateway, mapping.getStartNode());
+            builder.createSequenceFlow(mapping.getEndNode(), catchEvent);
+        }
+
+        for (OnAlarm alarmEvent : alarmEvents) {
+            mapping = alarmEvent.toBPMN(builder, startGateway);
+            builder.createSequenceFlow(startGateway, mapping.getStartNode());
+            builder.createSequenceFlow(mapping.getEndNode(), catchEvent);
+        }
+
+        return new MappedPair(startGateway, catchEvent);
+    }
+
     public void addMessageEvent(OnMessage messageEvent) {
         this.messageEvents.add(messageEvent);
     }
 
     public void addAlarmEvent(OnAlarm alarmEvent) {
         this.alarmEvents.add(alarmEvent);
-    }
-
-    @Override
-    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
-        return null;
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Pick.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Pick.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.structured;
 
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ public class Pick extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         return null;
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/RepeatUntil.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/RepeatUntil.java
@@ -14,30 +14,31 @@ public class RepeatUntil extends LoopActivity {
 
     @Override
     public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
-        FlowNode subProcess;
+        /*
+         * The Camunda BPMN API does not include a loop characteristic,
+         * therefore the loop is implemented with gateways where the condition is checked.
+         */
+        ExclusiveGateway afterGateway = builder.createElement(ExclusiveGateway.class);
 
-        if (children.size() != 1 || !(children.get(0) instanceof Scope)) {
-            subProcess = builder.createElement(SubProcess.class);
-            builder.setCurrentScope(subProcess);
+        // Note: In this implementation a loop is always wrapped inside a subprocess
+        SubProcess subProcess = builder.createElement(SubProcess.class);
+        builder.setCurrentScope(subProcess);
 
-            FlowNode lastNode = builder.createElement(StartEvent.class);
-            for (BPELObject child : children) {
-                MappedPair mapping = child.toBPMN(builder, lastNode);
-                builder.createSequenceFlow(lastNode, mapping.getStartNode());
-                lastNode = mapping.getEndNode();
-            }
-
-            FlowNode end = builder.createElement(EndEvent.class);
-            builder.createSequenceFlow(lastNode, end);
-
-            builder.setCurrentScope((BpmnModelElementInstance) subProcess.getParentElement());
-        } else {
-            subProcess = children.get(0).toBPMN(builder, from).getStartNode();
+        FlowNode lastNode = builder.createElement(StartEvent.class);
+        for (BPELObject child : children) {
+            MappedPair mapping = child.toBPMN(builder, lastNode);
+            builder.createSequenceFlow(lastNode, mapping.getStartNode());
+            lastNode = mapping.getEndNode();
         }
 
-        ExclusiveGateway afterGateway = builder.createElement(ExclusiveGateway.class);
+        FlowNode end = builder.createElement(EndEvent.class);
+        builder.createSequenceFlow(lastNode, end);
+
+        builder.setCurrentScope((BpmnModelElementInstance) subProcess.getParentElement());
+
         builder.createSequenceFlow(subProcess, afterGateway);
 
+        // Add check to validate if it as to run again.
         builder.prepareConditionalSequenceFlow(condition);
         builder.createSequenceFlow(afterGateway, subProcess);
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Scope.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Scope.java
@@ -1,10 +1,13 @@
 package org.bpel2bpmn.models.bpel.activities.structured;
 
+import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
 import org.bpel2bpmn.utilities.structures.MappedPair;
+import org.camunda.bpm.model.bpmn.instance.BpmnModelElementInstance;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
+import org.camunda.bpm.model.bpmn.instance.SubProcess;
 
 import java.util.ArrayList;
 
@@ -22,7 +25,24 @@ public class Scope extends Activity {
     }
 
     @Override
-    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
-        return null;
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+        SubProcess subProcess = builder.createElement(SubProcess.class);
+        builder.setCurrentScope(subProcess);
+
+        // Map and connect children.
+        FlowNode lastElement = null;
+        for (BPELObject child : children) {
+            MappedPair mapping = child.toBPMN(builder, lastElement);
+            if (!mapping.isEmpty()) {
+                builder.createSequenceFlow(lastElement, mapping.getStartNode());
+                lastElement = mapping.getEndNode();
+            }
+        }
+
+        // Note: Fault handlers aren't mapped for subprocesses
+
+        builder.setCurrentScope((BpmnModelElementInstance) subProcess.getParentElement());
+
+        return new MappedPair(subProcess);
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Scope.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Scope.java
@@ -29,6 +29,8 @@ public class Scope extends Activity {
         SubProcess subProcess = builder.createElement(SubProcess.class);
         builder.setCurrentScope(subProcess);
 
+        // Note: Partnerlinks are not implemented for a scope.
+
         // Map and connect children.
         FlowNode lastElement = null;
         for (BPELObject child : children) {
@@ -39,7 +41,7 @@ public class Scope extends Activity {
             }
         }
 
-        // Note: Fault handlers aren't mapped for subprocesses
+        // Note: Fault handlers aren't mapped for subprocesses.
 
         builder.setCurrentScope((BpmnModelElementInstance) subProcess.getParentElement());
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Scope.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Scope.java
@@ -3,6 +3,7 @@ package org.bpel2bpmn.models.bpel.activities.structured;
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 import java.util.ArrayList;
@@ -21,7 +22,7 @@ public class Scope extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         return null;
     }
 }

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Sequence.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Sequence.java
@@ -41,7 +41,7 @@ public class Sequence extends Activity {
             // Set start node of this sequence
             if (isFirstChild) {
                 result.setStartNode(mapping.getStartNode());
-                isFirstChild = false;
+                if (result.getStartNode() != null) isFirstChild = false;
             }
         }
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Sequence.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Sequence.java
@@ -4,6 +4,7 @@ import org.bpel2bpmn.exceptions.BPELConversionException;
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.models.bpel.activities.Activity;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 import java.util.ArrayList;
@@ -18,19 +19,27 @@ public class Sequence extends Activity {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
         FlowNode lastElement = from;
-        FlowNode currentElement;
+        MappedPair result = new MappedPair();
 
+        boolean isFirstChild = true;
         for (BPELObject child : children) {
-            currentElement = child.toBPMN(builder, lastElement);
-            if (!lastElement.equals(currentElement)) {
-                builder.createSequenceFlow(lastElement, currentElement);
+            MappedPair mapping = child.toBPMN(builder, lastElement);
+            if (!mapping.isEmpty()) {
+                builder.createSequenceFlow(lastElement, mapping.getStartNode());
+                lastElement = mapping.getEndNode();
             }
-            lastElement = currentElement;
+
+            if (isFirstChild) {
+                result.setStartNode(mapping.getStartNode());
+                isFirstChild = false;
+            }
         }
 
-        return lastElement;
+        result.setEndNode(lastElement);
+
+        return result;
     }
 
     @Override

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Sequence.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/Sequence.java
@@ -20,17 +20,25 @@ public class Sequence extends Activity {
 
     @Override
     public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) throws BPELConversionException {
-        FlowNode lastElement = from;
         MappedPair result = new MappedPair();
+        FlowNode lastElement = null;
 
         boolean isFirstChild = true;
         for (BPELObject child : children) {
+            // Map child activity to bpmm
             MappedPair mapping = child.toBPMN(builder, lastElement);
-            if (!mapping.isEmpty()) {
+
+            // If a start node is defined and mapping is returned, connect them.
+            if (lastElement != null && !mapping.isEmpty()) {
                 builder.createSequenceFlow(lastElement, mapping.getStartNode());
+            }
+
+            // Set end node of mapping as next element to connect to
+            if (!mapping.isEmpty()) {
                 lastElement = mapping.getEndNode();
             }
 
+            // Set start node of this sequence
             if (isFirstChild) {
                 result.setStartNode(mapping.getStartNode());
                 isFirstChild = false;

--- a/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/While.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/activities/structured/While.java
@@ -44,6 +44,7 @@ public class While extends LoopActivity {
 
         builder.createSequenceFlow(subProcess, afterGateway);
 
+        // Add check to validate if it as to run again.
         builder.prepareConditionalSequenceFlow(condition);
         builder.createSequenceFlow(afterGateway, subProcess);
 

--- a/src/main/java/org/bpel2bpmn/models/bpel/generic/Documentation.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/generic/Documentation.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.generic;
 
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 
 public class Documentation extends BPELObject {
@@ -12,11 +13,11 @@ public class Documentation extends BPELObject {
         this.content = content;
     }
 
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         org.camunda.bpm.model.bpmn.instance.Documentation bpmnDoc = builder.createElement(org.camunda.bpm.model.bpmn.instance.Documentation.class);
         bpmnDoc.setTextContent(content);
 
-        return from;
+        return new MappedPair();
     }
 
     /*

--- a/src/main/java/org/bpel2bpmn/models/bpel/generic/Import.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/generic/Import.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.generic;
 
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
 import org.camunda.bpm.model.bpmn.instance.Definitions;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
@@ -22,7 +23,7 @@ public class Import extends BPELObject {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
         Definitions definitions = builder.getModelInstance().getDefinitions();
         org.camunda.bpm.model.bpmn.instance.Import importInstance = builder.createElement(definitions, org.camunda.bpm.model.bpmn.instance.Import.class);
 
@@ -34,7 +35,7 @@ public class Import extends BPELObject {
             importInstance.setLocation(getLocation());
         }
 
-        return from;
+        return new MappedPair();
     }
 
     public ValidationResult validate() {

--- a/src/main/java/org/bpel2bpmn/models/bpel/generic/PartnerLink.java
+++ b/src/main/java/org/bpel2bpmn/models/bpel/generic/PartnerLink.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.generic;
 
 import org.bpel2bpmn.models.bpel.BPELObject;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.bpel2bpmn.utilities.validation.ValidationResult;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.Participant;
@@ -52,8 +53,8 @@ public class PartnerLink extends BPELObject {
     }
 
     @Override
-    public FlowNode toBPMN(BPMNBuilder builder, FlowNode from) {
-        return from;
+    public MappedPair toBPMN(BPMNBuilder builder, FlowNode from) {
+        return new MappedPair();
     }
 
     /*

--- a/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
+++ b/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
@@ -8,6 +8,7 @@ import org.bpel2bpmn.models.bpel.activities.basic.Assign;
 import org.bpel2bpmn.models.bpel.activities.basic.Empty;
 import org.bpel2bpmn.models.bpel.activities.basic.Exit;
 import org.bpel2bpmn.models.bpel.activities.basic.Rethrow;
+import org.bpel2bpmn.models.bpel.activities.structured.RepeatUntil;
 import org.bpel2bpmn.models.bpel.activities.structured.Scope;
 import org.bpel2bpmn.models.bpel.activities.structured.Sequence;
 import org.bpel2bpmn.models.bpel.activities.structured.While;
@@ -64,7 +65,7 @@ public class BPELParser {
         org.bpel2bpmn.models.bpel.BPELObject bpelObject;
 
         boolean parseChildren = true; // If false, children are parsed within element parser.
-        switch (element.getName().toLowerCase()) {
+        switch (element.getName()) {
             case "documentation":
                 bpelObject = DocumentationParser.parse(element);
                 parseChildren = false;
@@ -103,6 +104,10 @@ public class BPELParser {
                 break;
             case Activity.RECEIVE:
                 bpelObject = ReceiveParser.parse(element);
+                parseChildren = false;
+                break;
+            case Activity.REPEATUNTIL:
+                bpelObject = LoopParser.parse(element, RepeatUntil.class);
                 parseChildren = false;
                 break;
             case Activity.REPLY:

--- a/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
+++ b/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
@@ -103,6 +103,7 @@ public class BPELParser {
                 break;
             case Activity.RECEIVE:
                 bpelObject = ReceiveParser.parse(element);
+                parseChildren = false;
                 break;
             case Activity.REPLY:
                 bpelObject = ReplyParser.parse(element);

--- a/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
+++ b/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
@@ -8,6 +8,7 @@ import org.bpel2bpmn.models.bpel.activities.basic.Assign;
 import org.bpel2bpmn.models.bpel.activities.basic.Empty;
 import org.bpel2bpmn.models.bpel.activities.basic.Exit;
 import org.bpel2bpmn.models.bpel.activities.basic.Rethrow;
+import org.bpel2bpmn.models.bpel.activities.structured.Scope;
 import org.bpel2bpmn.models.bpel.activities.structured.Sequence;
 import org.bpel2bpmn.models.bpel.activities.structured.While;
 import org.bpel2bpmn.utilities.parsers.model.ProcessParser;
@@ -109,6 +110,9 @@ public class BPELParser {
                 break;
             case Activity.RETHROW:
                 bpelObject = BPELObjectParser.parse(element, Rethrow.class);
+                break;
+            case "scope":
+                bpelObject = BPELObjectParser.parse(element, Scope.class);
                 break;
             case Activity.SEQUENCE:
                 bpelObject = BPELObjectParser.parse(element, Sequence.class);

--- a/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
+++ b/src/main/java/org/bpel2bpmn/utilities/parsers/BPELParser.java
@@ -8,10 +8,7 @@ import org.bpel2bpmn.models.bpel.activities.basic.Assign;
 import org.bpel2bpmn.models.bpel.activities.basic.Empty;
 import org.bpel2bpmn.models.bpel.activities.basic.Exit;
 import org.bpel2bpmn.models.bpel.activities.basic.Rethrow;
-import org.bpel2bpmn.models.bpel.activities.structured.RepeatUntil;
-import org.bpel2bpmn.models.bpel.activities.structured.Scope;
-import org.bpel2bpmn.models.bpel.activities.structured.Sequence;
-import org.bpel2bpmn.models.bpel.activities.structured.While;
+import org.bpel2bpmn.models.bpel.activities.structured.*;
 import org.bpel2bpmn.utilities.parsers.model.ProcessParser;
 import org.bpel2bpmn.utilities.parsers.model.activities.BPELObjectParser;
 import org.bpel2bpmn.utilities.parsers.model.activities.basic.*;
@@ -81,6 +78,10 @@ public class BPELParser {
                 break;
             case Activity.FLOW:
                 bpelObject = FlowParser.parse(element);
+                parseChildren = false;
+                break;
+            case Activity.FOREACH:
+                bpelObject = BPELObjectParser.parse(element, ForEach.class);
                 parseChildren = false;
                 break;
             case Activity.IF:

--- a/src/main/java/org/bpel2bpmn/utilities/parsers/model/activities/structured/FlowParser.java
+++ b/src/main/java/org/bpel2bpmn/utilities/parsers/model/activities/structured/FlowParser.java
@@ -44,7 +44,7 @@ public class FlowParser {
                     String name = child.getAttributeValue("name");
 
                     if (name != null) {
-                        flow.addLink(child.getAttributeValue("name"));
+                        flow.addLink(name);
                     } else {
                         throw new BPELParseException("Link object should contain a 'name' attribute.");
                     }

--- a/src/main/java/org/bpel2bpmn/utilities/parsers/model/activities/structured/PickParser.java
+++ b/src/main/java/org/bpel2bpmn/utilities/parsers/model/activities/structured/PickParser.java
@@ -7,6 +7,8 @@ import org.bpel2bpmn.models.bpel.activities.structured.OnMessage;
 import org.bpel2bpmn.models.bpel.activities.structured.Pick;
 import org.bpel2bpmn.utilities.parsers.BPELParser;
 import org.bpel2bpmn.utilities.parsers.model.activities.basic.WaitParser;
+import org.bpel2bpmn.utilities.validation.ValidationResult;
+import org.jdom.Attribute;
 import org.jdom.Element;
 
 public class PickParser {
@@ -38,7 +40,19 @@ public class PickParser {
     private static OnMessage parseOnMessage(Element element) throws BPELParseException {
         OnMessage event = new OnMessage();
 
-        // TODO: Implement message event (probably Receive).
+        // Parse onMessage attributes
+        for (String attributeName : OnMessage.ATTRIBUTES) {
+            Attribute attribute = element.getAttribute(attributeName);
+            if (attribute != null) {
+                event.addAttribute(attributeName, attribute.getValue());
+            }
+        }
+
+        // Validate onMessage event
+        ValidationResult validationResult = event.validate();
+        if (!validationResult.isValid()) {
+            throw new BPELParseException(validationResult.getMessage());
+        }
 
         BPELParser.parseChildren(event, element);
 

--- a/src/main/java/org/bpel2bpmn/utilities/structures/MappedPair.java
+++ b/src/main/java/org/bpel2bpmn/utilities/structures/MappedPair.java
@@ -25,7 +25,7 @@ public class MappedPair {
     }
 
     public boolean isEmpty() {
-        return (startNode == null && endNode == null);
+        return (startNode == null || endNode == null);
     }
 
     /*

--- a/src/main/java/org/bpel2bpmn/utilities/structures/MappedPair.java
+++ b/src/main/java/org/bpel2bpmn/utilities/structures/MappedPair.java
@@ -1,0 +1,50 @@
+package org.bpel2bpmn.utilities.structures;
+
+import org.camunda.bpm.model.bpmn.instance.FlowNode;
+
+public class MappedPair {
+
+    private FlowNode startNode;
+    private FlowNode endNode;
+
+    public MappedPair() {
+        this(null, null);
+    }
+
+    public MappedPair(FlowNode node) {
+        this(node, node);
+    }
+
+    public MappedPair(FlowNode startNode, FlowNode endNode) {
+        this.startNode = startNode;
+        this.endNode = endNode;
+    }
+
+    public boolean isSingleNode() {
+        return startNode.equals(endNode);
+    }
+
+    public boolean isEmpty() {
+        return (startNode == null && endNode == null);
+    }
+
+    /*
+     * Getters & Setters
+     */
+
+    public FlowNode getStartNode() {
+        return startNode;
+    }
+
+    public void setStartNode(FlowNode startNode) {
+        this.startNode = startNode;
+    }
+
+    public FlowNode getEndNode() {
+        return endNode;
+    }
+
+    public void setEndNode(FlowNode endNode) {
+        this.endNode = endNode;
+    }
+}

--- a/src/test/java/org/bpel2bpmn/models/bpel/activities/basic/EmptyTest.java
+++ b/src/test/java/org/bpel2bpmn/models/bpel/activities/basic/EmptyTest.java
@@ -2,11 +2,13 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import factories.BPMNBuilderFactory;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.StartEvent;
 import org.junit.Before;
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class EmptyTest {
@@ -23,9 +25,9 @@ public class EmptyTest {
     @Test
     public void toBPMN() {
         FlowNode start = builder.createElement(StartEvent.class);
-        FlowNode bpmn = empty.toBPMN(builder, start);
+        MappedPair bpmn = empty.toBPMN(builder, start);
 
-        assertEquals(start, bpmn);
+        assertTrue(bpmn.isEmpty());
     }
 
 }

--- a/src/test/java/org/bpel2bpmn/models/bpel/activities/basic/ExitTest.java
+++ b/src/test/java/org/bpel2bpmn/models/bpel/activities/basic/ExitTest.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import factories.BPMNBuilderFactory;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.impl.instance.EndEventImpl;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.StartEvent;
@@ -25,9 +26,10 @@ public class ExitTest {
     @Test
     public void toBPMN() {
         FlowNode start = builder.createElement(StartEvent.class);
-        FlowNode bpmn = exit.toBPMN(builder, start);
+        MappedPair bpmn = exit.toBPMN(builder, start);
 
-        assertEquals(EndEventImpl.class, bpmn.getClass());
-        assertEquals(1, bpmn.getChildElementsByType(TerminateEventDefinition.class).size());
+        assertEquals(EndEventImpl.class, bpmn.getStartNode().getClass());
+        assertEquals(EndEventImpl.class, bpmn.getEndNode().getClass());
+        assertEquals(1, bpmn.getStartNode().getChildElementsByType(TerminateEventDefinition.class).size());
     }
 }

--- a/src/test/java/org/bpel2bpmn/models/bpel/activities/basic/WaitTest.java
+++ b/src/test/java/org/bpel2bpmn/models/bpel/activities/basic/WaitTest.java
@@ -2,6 +2,7 @@ package org.bpel2bpmn.models.bpel.activities.basic;
 
 import factories.BPMNBuilderFactory;
 import org.bpel2bpmn.utilities.builders.BPMNBuilder;
+import org.bpel2bpmn.utilities.structures.MappedPair;
 import org.camunda.bpm.model.bpmn.impl.instance.IntermediateCatchEventImpl;
 import org.camunda.bpm.model.bpmn.impl.instance.TimerEventDefinitionImpl;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
@@ -31,10 +32,12 @@ public class WaitTest {
         wait.setTimer(true);
         wait.setTimeExpression(timeExpression);
 
-        FlowNode bpmn = wait.toBPMN(builder, start);
-        TimerEventDefinitionImpl timer = (TimerEventDefinitionImpl) bpmn.getChildElementsByType(TimerEventDefinition.class).toArray()[0];
+        MappedPair bpmn = wait.toBPMN(builder, start);
+        TimerEventDefinitionImpl timer = (TimerEventDefinitionImpl) bpmn.getStartNode()
+                                                                        .getChildElementsByType(TimerEventDefinition.class)
+                                                                        .toArray()[0];
 
-        assertEquals(IntermediateCatchEventImpl.class, bpmn.getClass());
+        assertEquals(IntermediateCatchEventImpl.class, bpmn.getStartNode().getClass());
         assertEquals(timeExpression, timer.getTimeDuration().getTextContent());
     }
 
@@ -44,7 +47,7 @@ public class WaitTest {
         wait.setTimer(false);
         wait.setTimeExpression(timeExpression);
 
-        FlowNode bpmn = wait.toBPMN(builder, start);
+        FlowNode bpmn = wait.toBPMN(builder, start).getStartNode();
         TimerEventDefinitionImpl timer = (TimerEventDefinitionImpl) bpmn.getChildElementsByType(TimerEventDefinition.class).toArray()[0];
 
         assertEquals(IntermediateCatchEventImpl.class, bpmn.getClass());

--- a/src/test/java/org/bpel2bpmn/models/bpel/activities/structured/IfTest.java
+++ b/src/test/java/org/bpel2bpmn/models/bpel/activities/structured/IfTest.java
@@ -42,7 +42,7 @@ public class IfTest {
         ifObject.addElseIfBranch(elseIfBranch);
         ifObject.setElseBranch(elseBranch);
 
-        FlowNode result = ifObject.toBPMN(builder, start);
+        FlowNode result = ifObject.toBPMN(builder, start).getStartNode();
 
         Object[] children = builder.getExecutableProcess().getFlowElements().toArray();
 

--- a/src/test/java/org/bpel2bpmn/models/bpel/generic/DocumentationTest.java
+++ b/src/test/java/org/bpel2bpmn/models/bpel/generic/DocumentationTest.java
@@ -26,7 +26,7 @@ public class DocumentationTest {
     public void toBPMN() {
         FlowNode start = builder.createElement(StartEvent.class);
 
-        FlowNode last = documentation.toBPMN(builder, start);
+        FlowNode last = documentation.toBPMN(builder, start).getStartNode();
 
         Process process = builder.getExecutableProcess();
         Object[] children = process.getChildElementsByType(org.camunda.bpm.model.bpmn.instance.Documentation.class).toArray();


### PR DESCRIPTION
The `toBPMN()` methods now return a pair of the first and last node of that mapping. The parent activities now connect all the children, instead of the children connecting themselves to the given Node and returning their last node.

All structured activities are now implemented and adjusted to this new approach